### PR TITLE
Fix order of comments in speculationrules php

### DIFF
--- a/view/frontend/templates/speculation-rules.phtml
+++ b/view/frontend/templates/speculation-rules.phtml
@@ -1,13 +1,13 @@
-<?php
-/** @var Template $block */
-/** @var Escaper $escaper */
-
-/** @var SecureHtmlRenderer $secureRenderer */
+<?php declare(strict_types=1);
 
 use Magento\Framework\Escaper;
 use Magento\Framework\View\Element\Template;
 use Magento\Framework\View\Helper\SecureHtmlRenderer;
 use MageOS\ThemeOptimization\ViewModel\SpeculationRules;
+
+/** @var Template $block */
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
 
 /** @var SpeculationRules $viewModel */
 $viewModel = $block->getViewModel();


### PR DESCRIPTION
The current order makes the `use`s in the phtml unused, from a editor perspective.

This PR fixes the order.