### PR TITLE
Speculation Rules | Clear prefetch & prerender cache after cart item action

### DIFF
--- a/Observer/AddClearSiteDataHeader.php
+++ b/Observer/AddClearSiteDataHeader.php
@@ -9,7 +9,7 @@ use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 
 /**
- * Stale prefetches can be cleared using the `prefetchCache` and `prerenderCache` value of the `Clear-Site-Data response header.
+ * Stale speculative loads can be cleared using the `prefetchCache` and `prerenderCache` value of the `Clear-Site-Data` response header.
  * See [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Clear-Site-Data#prefetchcache)
  */
 class AddClearSiteDataHeader implements ObserverInterface

--- a/Observer/AddClearSiteDataHeader.php
+++ b/Observer/AddClearSiteDataHeader.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Basecom\Catalog\Observer;
+
+use Magento\Framework\App\Response\HttpInterface;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+
+/**
+ * Stale prefetches can be cleared using the `prefetchCache` and `prerenderCache` value of the `Clear-Site-Data response header.
+ * See [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Clear-Site-Data#prefetchcache)
+ */
+class AddClearSiteDataHeader implements ObserverInterface
+{
+    public function execute(Observer $observer): void
+    {
+        /** @var HttpInterface|null $response */
+        $response = $observer->getResponse();
+
+        if (!$response) {
+            return;
+        }
+
+        $response->setHeader(
+            'Clear-Site-Data',
+            '"prefetchCache", "prerenderCache"',
+            true
+        );
+    }
+}

--- a/Observer/AddClearSiteDataHeader.php
+++ b/Observer/AddClearSiteDataHeader.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Basecom\Catalog\Observer;
+namespace MageOS\ThemeOptimization\Observer;
 
 use Magento\Framework\App\Response\HttpInterface;
 use Magento\Framework\Event\Observer;

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+    <!-- Clear the prefetch & prerender cache after a product is successfully added to the cart -->
+    <event name="checkout_cart_add_product_complete">
+        <observer name="clear_site_data_header_add" instance="Basecom\Catalog\Observer\AddClearSiteDataHeader"/>
+    </event>
+    <!-- Clear the prefetch & prerender cache after a cart item is successfully -->
+    <event name="checkout_cart_update_item_complete">
+        <observer name="clear_site_data_header_update" instance="Basecom\Catalog\Observer\AddClearSiteDataHeader"/>
+    </event>
+</config>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -4,10 +4,10 @@
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
     <!-- Clear the prefetch & prerender cache after a product is successfully added to the cart -->
     <event name="checkout_cart_add_product_complete">
-        <observer name="clear_site_data_header_add" instance="Basecom\Catalog\Observer\AddClearSiteDataHeader"/>
+        <observer name="clear_site_data_header_add" instance="MageOS\ThemeOptimization\Observer\AddClearSiteDataHeader"/>
     </event>
     <!-- Clear the prefetch & prerender cache after a cart item is successfully -->
     <event name="checkout_cart_update_item_complete">
-        <observer name="clear_site_data_header_update" instance="Basecom\Catalog\Observer\AddClearSiteDataHeader"/>
+        <observer name="clear_site_data_header_update" instance="MageOS\ThemeOptimization\Observer\AddClearSiteDataHeader"/>
     </event>
 </config>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -6,7 +6,7 @@
     <event name="checkout_cart_add_product_complete">
         <observer name="clear_site_data_header_add" instance="MageOS\ThemeOptimization\Observer\AddClearSiteDataHeader"/>
     </event>
-    <!-- Clear the prefetch & prerender cache after a cart item is successfully -->
+    <!-- Clear the prefetch & prerender cache after a cart item is successfully updated -->
     <event name="checkout_cart_update_item_complete">
         <observer name="clear_site_data_header_update" instance="MageOS\ThemeOptimization\Observer\AddClearSiteDataHeader"/>
     </event>


### PR DESCRIPTION
When using Speculation Rules, you may run into the issue of serving stale content.

* A user clicks on a product
* They trigger a speculative load (let's say a prefetch) on a familiar product or link
* They add the product to their cart
* When they navigate to the prefetched site, they will be served stale content from the prefetch cache

The **Clear-Site-Data** header can be used to clear the prefetch and prerender cache, which is used by the Speculation Rules API (see [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Clear-Site-Data#prefetchcache)). This ensures, that previous speculative loads will be discarded, so the user will not be served stale content.

I have added an observer for the following events, which include the `$response` object:
* `checkout_cart_add_product_complete`
* `checkout_cart_update_item_complete`

The resulting header will look like this:
`Clear-Site-Data "prefetchCache", "prerenderCache"`

ℹ️ I am not sure if this problem persists when adding a product to the cart or updating the quantity triggers a reload. This is primarily concerning AJAX calls.