### PR TITLE
Add PHP 8.4 and PHP 8.5 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+## [2.3.0] - 2026-04-21
+
+### Added
+- PHP 8.4 and PHP 8.5 compatibility.
+- Explicit `php` constraint in `composer.json` (`~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0`).
+
+### Changed
+- Added `declare(strict_types=1)` to all PHP classes.
+- Added explicit return types on all methods (including `Setup\Patch\Data\UpdateSpeculationRulesConfigPathPatch::apply()`, `getAliases()` and `getDependencies()`).
+- Typed class constants (`const string`, `const array`) to take advantage of PHP 8.3+ typed constants.
+- Replaced `strpos($s, $needle) === 0` with `str_starts_with()` for clarity.
+- Typed nullable parameters explicitly (e.g. `int|string|null $store`) to avoid the PHP 8.4 implicit nullable deprecation.
+- Made constructor-promoted properties and helper methods `protected` instead of `private` for easier extension by downstream modules.
+- Minor refactors (`array_map` in place of manual loops, `unset` of loop reference variable).
+
+### Notes
+- No public API change: all previously `public` methods keep the same signatures.
+- Extensions that relied on subclassing internals now benefit from `protected` visibility.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [2.3.0] - 2026-04-21
+## [2.3.0] - 2026-05-11
 
 ### Added
 - PHP 8.4 and PHP 8.5 compatibility.
@@ -13,7 +13,3 @@
 - Typed nullable parameters explicitly (e.g. `int|string|null $store`) to avoid the PHP 8.4 implicit nullable deprecation.
 - Made constructor-promoted properties and helper methods `protected` instead of `private` for easier extension by downstream modules.
 - Minor refactor: `unset` of loop reference variable after foreach-by-reference.
-
-### Notes
-- No public API change: all previously `public` methods keep the same signatures.
-- Extensions that relied on subclassing internals now benefit from `protected` visibility.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,10 @@
 ### Changed
 - Added `declare(strict_types=1)` to all PHP classes.
 - Added explicit return types on all methods (including `Setup\Patch\Data\UpdateSpeculationRulesConfigPathPatch::apply()`, `getAliases()` and `getDependencies()`).
-- Typed class constants (`const string`, `const array`) to take advantage of PHP 8.3+ typed constants.
 - Replaced `strpos($s, $needle) === 0` with `str_starts_with()` for clarity.
 - Typed nullable parameters explicitly (e.g. `int|string|null $store`) to avoid the PHP 8.4 implicit nullable deprecation.
 - Made constructor-promoted properties and helper methods `protected` instead of `private` for easier extension by downstream modules.
-- Minor refactors (`array_map` in place of manual loops, `unset` of loop reference variable).
+- Minor refactor: `unset` of loop reference variable after foreach-by-reference.
 
 ### Notes
 - No public API change: all previously `public` methods keep the same signatures.

--- a/Plugin/Framework/App/Response/Http.php
+++ b/Plugin/Framework/App/Response/Http.php
@@ -8,10 +8,13 @@ use Magento\Framework\App\Response\Http as ResponseHttp;
 use Magento\PageCache\Model\Config;
 use Magento\Store\Model\ScopeInterface;
 
+/**
+ * Plugin to modify cache headers for BFCache functionality
+ */
 class Http
 {
-    public const string XML_PATH_ENABLE = 'system/bfcache/general/enable';
-    public const string XML_PATH_EXCLUDE_URL_PATTERNS = 'system/bfcache/scope/exclude_url_patterns';
+    public const XML_PATH_ENABLE = 'system/bfcache/general/enable';
+    public const XML_PATH_EXCLUDE_URL_PATTERNS = 'system/bfcache/scope/exclude_url_patterns';
 
     protected bool $isRequestCacheable = false;
 
@@ -23,6 +26,8 @@ class Http
     }
 
     /**
+     * Intercept before setting no-cache headers to determine if request is cacheable
+     *
      * @param ResponseHttp $subject
      * @return void
      */
@@ -46,6 +51,8 @@ class Http
     }
 
     /**
+     * Update cache headers after setting no-cache headers
+     *
      * @param ResponseHttp $subject
      * @param mixed $result
      * @return mixed
@@ -70,21 +77,27 @@ class Http
     }
 
     /**
+     * Check if request is cacheable based on cache control header
+     *
      * @param string $cacheControl
      * @return bool
      */
     protected function isRequestCacheable(string $cacheControl): bool
     {
+        // FPC hits will not have public or private cache control directives -- already processed
         if (!str_contains($cacheControl, 'public')
             && !str_contains($cacheControl, 'private')
             && !str_contains($cacheControl, 'no-store')) {
             return true;
         }
 
+        // FPC misses will be cacheable if they have a public directive
         return (bool)preg_match('/public.*s-maxage=(\d+)/', $cacheControl);
     }
 
     /**
+     * Check if the request URI contains any excluded URL patterns (case-insensitive, partial match).
+     *
      * @param string $requestURI
      * @return bool
      */
@@ -106,6 +119,8 @@ class Http
     }
 
     /**
+     * Parse exclude patterns from config string.
+     *
      * @param string $patterns
      * @return array
      */
@@ -115,6 +130,8 @@ class Http
     }
 
     /**
+     * Check if BFCache is enabled
+     *
      * @return bool
      */
     protected function isEnabled(): bool
@@ -126,6 +143,8 @@ class Http
     }
 
     /**
+     * Get configuration value by path
+     *
      * @param string $configPath
      * @param int|string|null $store
      * @return string

--- a/Plugin/Framework/App/Response/Http.php
+++ b/Plugin/Framework/App/Response/Http.php
@@ -4,42 +4,29 @@ namespace MageOS\ThemeOptimization\Plugin\Framework\App\Response;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\Request\Http as HttpRequest;
+use Magento\Framework\App\Response\Http as ResponseHttp;
 use Magento\PageCache\Model\Config;
 use Magento\Store\Model\ScopeInterface;
 
-/**
- * Plugin to modify cache headers for BFCache functionality
- */
 class Http
 {
-    /** @var string */
-    public const XML_PATH_ENABLE = 'system/bfcache/general/enable';
+    public const string XML_PATH_ENABLE = 'system/bfcache/general/enable';
+    public const string XML_PATH_EXCLUDE_URL_PATTERNS = 'system/bfcache/scope/exclude_url_patterns';
 
-    /** @var string */
-    public const XML_PATH_EXCLUDE_URL_PATTERNS = 'system/bfcache/scope/exclude_url_patterns';
+    protected bool $isRequestCacheable = false;
 
-    /** @var bool */
-    private $isRequestCacheable = false;
-
-    /**
-     * @param Config $config
-     * @param ScopeConfigInterface $scopeConfig
-     * @param HttpRequest $request
-     */
     public function __construct(
-        private Config $config,
-        private ScopeConfigInterface $scopeConfig,
-        private HttpRequest $request
+        protected Config $config,
+        protected ScopeConfigInterface $scopeConfig,
+        protected HttpRequest $request
     ) {
     }
 
     /**
-     * Intercept before setting no-cache headers to determine if request is cacheable
-     *
-     * @param \Magento\Framework\App\Response\Http $subject
+     * @param ResponseHttp $subject
      * @return void
      */
-    public function beforeSetNoCacheHeaders(\Magento\Framework\App\Response\Http $subject): void
+    public function beforeSetNoCacheHeaders(ResponseHttp $subject): void
     {
         if ($this->config->getType() !== Config::BUILT_IN || !$this->isEnabled()) {
             return;
@@ -59,13 +46,11 @@ class Http
     }
 
     /**
-     * Update cache headers after setting no-cache headers
-     *
-     * @param \Magento\Framework\App\Response\Http $subject
+     * @param ResponseHttp $subject
      * @param mixed $result
      * @return mixed
      */
-    public function afterSetNoCacheHeaders(\Magento\Framework\App\Response\Http $subject, $result)
+    public function afterSetNoCacheHeaders(ResponseHttp $subject, mixed $result): mixed
     {
         if ($this->config->getType() !== Config::BUILT_IN || !$this->isEnabled()) {
             return $result;
@@ -77,7 +62,6 @@ class Http
         }
 
         if ($this->isRequestCacheable === true) {
-            $cacheControlHeader = $subject->getHeader('Cache-Control');
             $cacheControlHeader->removeDirective('no-store');
         }
         $this->isRequestCacheable = false;
@@ -86,35 +70,29 @@ class Http
     }
 
     /**
-     * Check if request is cacheable based on cache control header
-     *
      * @param string $cacheControl
      * @return bool
      */
-    private function isRequestCacheable(string $cacheControl): bool
+    protected function isRequestCacheable(string $cacheControl): bool
     {
-        // FPC hits will not have public or private cache control directives -- already processed
         if (!str_contains($cacheControl, 'public')
             && !str_contains($cacheControl, 'private')
             && !str_contains($cacheControl, 'no-store')) {
             return true;
         }
 
-        // FPC misses will be cacheable if they have a public directive
-        return (bool) preg_match('/public.*s-maxage=(\d+)/', $cacheControl);
+        return (bool)preg_match('/public.*s-maxage=(\d+)/', $cacheControl);
     }
 
     /**
-     * Check if the request URI contains any excluded URL patterns (case-insensitive, partial match).
-     *
      * @param string $requestURI
      * @return bool
      */
-    private function isRequestInExcludePatterns(string $requestURI): bool
+    protected function isRequestInExcludePatterns(string $requestURI): bool
     {
         $patterns = $this->getConfig(self::XML_PATH_EXCLUDE_URL_PATTERNS);
 
-        if (empty($patterns)) {
+        if ($patterns === '') {
             return false;
         }
 
@@ -128,22 +106,18 @@ class Http
     }
 
     /**
-     * Parse exclude patterns from config string.
-     *
      * @param string $patterns
      * @return array
      */
-    private function parseExcludePatterns(string $patterns): array
+    protected function parseExcludePatterns(string $patterns): array
     {
-        return array_filter(array_map('trim', explode("\n", $patterns)));
+        return array_values(array_filter(array_map('trim', explode("\n", $patterns))));
     }
 
     /**
-     * Check if BFCache is enabled
-     *
      * @return bool
      */
-    private function isEnabled(): bool
+    protected function isEnabled(): bool
     {
         return $this->scopeConfig->isSetFlag(
             self::XML_PATH_ENABLE,
@@ -152,13 +126,11 @@ class Http
     }
 
     /**
-     * Get configuration value by path
-     *
      * @param string $configPath
      * @param int|string|null $store
      * @return string
      */
-    private function getConfig(string $configPath, $store = null): string
+    protected function getConfig(string $configPath, int|string|null $store = null): string
     {
         return (string)$this->scopeConfig->getValue(
             $configPath,

--- a/Setup/Patch/Data/UpdateSpeculationRulesConfigPathPatch.php
+++ b/Setup/Patch/Data/UpdateSpeculationRulesConfigPathPatch.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace MageOS\ThemeOptimization\Setup\Patch\Data;
 
@@ -6,37 +6,21 @@ use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Zend_Db_Expr;
 
-/**
- * Update config path for speculation rules from version 1.0.0
- */
 class UpdateSpeculationRulesConfigPathPatch implements DataPatchInterface
 {
-    /**
-     * @var ModuleDataSetupInterface
-     */
-    private ModuleDataSetupInterface $moduleDataSetup;
-
-    /**
-     * @param ModuleDataSetupInterface $moduleDataSetup
-     */
     public function __construct(
-        ModuleDataSetupInterface $moduleDataSetup
-    )
-    {
-        $this->moduleDataSetup = $moduleDataSetup;
+        protected ModuleDataSetupInterface $moduleDataSetup
+    ) {
     }
 
     /**
-     * Do Upgrade.
-     *
-     * @return void
+     * @return self
      */
-    public function apply()
+    public function apply(): self
     {
-        $this->moduleDataSetup->getConnection()->startSetup();
-
-        // Change the core_config_data path for any 'dev/speculation_rules/*' values to 'system/speculation_rules/*'
         $connection = $this->moduleDataSetup->getConnection();
+        $connection->startSetup();
+
         $connection->update(
             $this->moduleDataSetup->getTable('core_config_data'),
             [
@@ -47,32 +31,23 @@ class UpdateSpeculationRulesConfigPathPatch implements DataPatchInterface
             ['path LIKE ?' => 'dev/speculation_rules/%']
         );
 
-        $this->moduleDataSetup->getConnection()->endSetup();
+        $connection->endSetup();
+
+        return $this;
     }
 
     /**
-     * Get aliases (previous names) for the patch.
-     *
      * @return string[]
      */
-    public function getAliases()
+    public function getAliases(): array
     {
         return [];
     }
 
     /**
-     * Get array of patches that have to be executed prior to this.
-     *
-     * Example of implementation:
-     *
-     * [
-     *      \Vendor_Name\Module_Name\Setup\Patch\Patch1::class,
-     *      \Vendor_Name\Module_Name\Setup\Patch\Patch2::class
-     * ]
-     *
      * @return string[]
      */
-    public static function getDependencies()
+    public static function getDependencies(): array
     {
         return [];
     }

--- a/Setup/Patch/Data/UpdateSpeculationRulesConfigPathPatch.php
+++ b/Setup/Patch/Data/UpdateSpeculationRulesConfigPathPatch.php
@@ -6,6 +6,9 @@ use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Zend_Db_Expr;
 
+/**
+ * Update config path for speculation rules from version 1.0.0
+ */
 class UpdateSpeculationRulesConfigPathPatch implements DataPatchInterface
 {
     public function __construct(
@@ -14,6 +17,8 @@ class UpdateSpeculationRulesConfigPathPatch implements DataPatchInterface
     }
 
     /**
+     * Do Upgrade.
+     *
      * @return self
      */
     public function apply(): self
@@ -21,6 +26,7 @@ class UpdateSpeculationRulesConfigPathPatch implements DataPatchInterface
         $connection = $this->moduleDataSetup->getConnection();
         $connection->startSetup();
 
+        // Change the core_config_data path for any 'dev/speculation_rules/*' values to 'system/speculation_rules/*'
         $connection->update(
             $this->moduleDataSetup->getTable('core_config_data'),
             [
@@ -37,6 +43,8 @@ class UpdateSpeculationRulesConfigPathPatch implements DataPatchInterface
     }
 
     /**
+     * Get aliases (previous names) for the patch.
+     *
      * @return string[]
      */
     public function getAliases(): array
@@ -45,6 +53,15 @@ class UpdateSpeculationRulesConfigPathPatch implements DataPatchInterface
     }
 
     /**
+     * Get array of patches that have to be executed prior to this.
+     *
+     * Example of implementation:
+     *
+     * [
+     *      \Vendor_Name\Module_Name\Setup\Patch\Patch1::class,
+     *      \Vendor_Name\Module_Name\Setup\Patch\Patch2::class
+     * ]
+     *
      * @return string[]
      */
     public static function getDependencies(): array

--- a/Test/Unit/ViewModel/SpeculationRulesTest.php
+++ b/Test/Unit/ViewModel/SpeculationRulesTest.php
@@ -9,6 +9,7 @@ use Magento\Framework\View\DesignInterface;
 use Magento\Framework\View\Element\Block\ArgumentInterface;
 use Magento\Store\Model\ScopeInterface;
 use MageOS\ThemeOptimization\ViewModel\SpeculationRules;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class SpeculationRulesTest extends TestCase
@@ -67,10 +68,8 @@ class SpeculationRulesTest extends TestCase
 
     // Test Category #2: Configuration Tests - isEnabled() method
 
-    /**
-     * @dataProvider enabledDataProvider
-     */
-    public function testIsEnabled($configValue, bool $expected): void
+    #[DataProvider('enabledDataProvider')]
+    public function testIsEnabled(mixed $configValue, bool $expected): void
     {
         $this->scopeConfigMock->expects($this->once())
             ->method('getValue')
@@ -81,7 +80,7 @@ class SpeculationRulesTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
-    public function enabledDataProvider(): array
+    public static function enabledDataProvider(): array
     {
         return [
             'string true' => ['1', true],
@@ -98,10 +97,8 @@ class SpeculationRulesTest extends TestCase
 
     // Test Category #3: Eagerness Mode Tests
 
-    /**
-     * @dataProvider eagernessDataProvider
-     */
-    public function testGetEagerness($configValue, string $expected): void
+    #[DataProvider('eagernessDataProvider')]
+    public function testGetEagerness(mixed $configValue, string $expected): void
     {
         $this->scopeConfigMock->expects($this->once())
             ->method('getValue')
@@ -112,7 +109,7 @@ class SpeculationRulesTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
-    public function eagernessDataProvider(): array
+    public static function eagernessDataProvider(): array
     {
         return [
             'conservative' => ['conservative', 'conservative'],

--- a/ViewModel/BfCache.php
+++ b/ViewModel/BfCache.php
@@ -8,34 +8,21 @@ use Magento\Framework\App\Http\Context;
 use Magento\Framework\View\Element\Block\ArgumentInterface;
 use Magento\Store\Model\ScopeInterface;
 
-/**
- * BFCache ViewModel
- * Provides data and configuration for BFCache templates.
- * Handles configuration management and business logic for frontend templates.
- */
 class BfCache implements ArgumentInterface
 {
-    /** @var string */
-    private const XML_PATH_ENABLE_USER_INTERACTION_RELOAD_MINICART =
+    protected const string XML_PATH_ENABLE_USER_INTERACTION_RELOAD_MINICART =
         'system/bfcache/general/enable_user_interaction_reload_minicart';
-        
-    /** @var string */
-    private const XML_PATH_AUTO_CLOSE_MENU_MOBILE =
+
+    protected const string XML_PATH_AUTO_CLOSE_MENU_MOBILE =
         'system/bfcache/general/auto_close_menu_mobile';
 
-    /**
-     * @param ScopeConfigInterface $scopeConfig
-     * @param Context $httpContext
-     */
     public function __construct(
-        private ScopeConfigInterface $scopeConfig,
-        private Context $httpContext
+        protected ScopeConfigInterface $scopeConfig,
+        protected Context $httpContext
     ) {
     }
 
     /**
-     * Check if mini cart should reload on user interaction
-     *
      * @return bool
      */
     public function isReloadMiniCartOnInteraction(): bool
@@ -47,8 +34,6 @@ class BfCache implements ArgumentInterface
     }
 
     /**
-     * Check if mobile menu should auto-close
-     *
      * @return bool
      */
     public function autoCloseMenuMobile(): bool
@@ -60,12 +45,10 @@ class BfCache implements ArgumentInterface
     }
 
     /**
-     * Check if customer is logged in
-     *
      * @return bool
      */
     public function isCustomerLoggedIn(): bool
     {
-        return (bool) $this->httpContext->getValue(CustomerContext::CONTEXT_AUTH);
+        return (bool)$this->httpContext->getValue(CustomerContext::CONTEXT_AUTH);
     }
 }

--- a/ViewModel/BfCache.php
+++ b/ViewModel/BfCache.php
@@ -8,12 +8,17 @@ use Magento\Framework\App\Http\Context;
 use Magento\Framework\View\Element\Block\ArgumentInterface;
 use Magento\Store\Model\ScopeInterface;
 
+/**
+ * BFCache ViewModel
+ * Provides data and configuration for BFCache templates.
+ * Handles configuration management and business logic for frontend templates.
+ */
 class BfCache implements ArgumentInterface
 {
-    protected const string XML_PATH_ENABLE_USER_INTERACTION_RELOAD_MINICART =
+    protected const XML_PATH_ENABLE_USER_INTERACTION_RELOAD_MINICART =
         'system/bfcache/general/enable_user_interaction_reload_minicart';
 
-    protected const string XML_PATH_AUTO_CLOSE_MENU_MOBILE =
+    protected const XML_PATH_AUTO_CLOSE_MENU_MOBILE =
         'system/bfcache/general/auto_close_menu_mobile';
 
     public function __construct(
@@ -23,6 +28,8 @@ class BfCache implements ArgumentInterface
     }
 
     /**
+     * Check if mini cart should reload on user interaction
+     *
      * @return bool
      */
     public function isReloadMiniCartOnInteraction(): bool
@@ -34,6 +41,8 @@ class BfCache implements ArgumentInterface
     }
 
     /**
+     * Check if mobile menu should auto-close
+     *
      * @return bool
      */
     public function autoCloseMenuMobile(): bool
@@ -45,6 +54,8 @@ class BfCache implements ArgumentInterface
     }
 
     /**
+     * Check if customer is logged in
+     *
      * @return bool
      */
     public function isCustomerLoggedIn(): bool

--- a/ViewModel/SpeculationRules.php
+++ b/ViewModel/SpeculationRules.php
@@ -1,36 +1,43 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace MageOS\ThemeOptimization\ViewModel;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Serialize\SerializerInterface;
 use Magento\Framework\UrlInterface;
-use Magento\Framework\View\Element\Block\ArgumentInterface;
 use Magento\Framework\View\DesignInterface;
+use Magento\Framework\View\Element\Block\ArgumentInterface;
 use Magento\Store\Model\ScopeInterface;
+use InvalidArgumentException;
 
 class SpeculationRules implements ArgumentInterface
 {
-    protected const CONFIG_PATH = 'system/speculation_rules/';
-    protected const MODE_PREFETCH = 'prefetch';
-    protected const MODE_PRERENDER = 'prerender';
-    protected const FETCH_MODES = [self::MODE_PREFETCH, self::MODE_PRERENDER];
-    protected const EAGERNESS_MODES = ['conservative', 'moderate', 'eager'];
+    protected const string CONFIG_PATH = 'system/speculation_rules/';
+    protected const string MODE_PREFETCH = 'prefetch';
+    protected const string MODE_PRERENDER = 'prerender';
+    protected const string EAGERNESS_DEFAULT = 'moderate';
+    protected const array FETCH_MODES = [self::MODE_PREFETCH, self::MODE_PRERENDER];
+    protected const array EAGERNESS_MODES = ['conservative', 'moderate', 'eager'];
 
     public function __construct(
         protected ScopeConfigInterface $scopeConfig,
-        protected UrlInterface         $urlBuilder,
-        protected SerializerInterface  $serializer,
-        protected DesignInterface      $viewDesign
-    )
-    {
+        protected UrlInterface $urlBuilder,
+        protected SerializerInterface $serializer,
+        protected DesignInterface $viewDesign
+    ) {
     }
 
+    /**
+     * @return bool
+     */
     public function isEnabled(): bool
     {
         return (bool)$this->getConfigValue('enable');
     }
 
+    /**
+     * @return string
+     */
     public function getMode(): string
     {
         $mode = $this->getConfigValue('mode');
@@ -42,6 +49,9 @@ class SpeculationRules implements ArgumentInterface
         return self::MODE_PREFETCH;
     }
 
+    /**
+     * @return string
+     */
     public function getEagerness(): string
     {
         $eagerness = $this->getConfigValue('eagerness');
@@ -50,12 +60,10 @@ class SpeculationRules implements ArgumentInterface
             return $eagerness;
         }
 
-        return 'moderate';
+        return self::EAGERNESS_DEFAULT;
     }
 
     /**
-     * Check if the current mode is prerender
-     *
      * @return bool
      */
     public function isPrerenderMode(): bool
@@ -64,10 +72,6 @@ class SpeculationRules implements ArgumentInterface
     }
 
     /**
-     * Get prerendering change script for customer data reinitialization
-     * Returns script only when prerender mode is enabled
-     * Uses different approaches for Hyva vs Luma themes
-     *
      * @return string
      */
     public function getPrerenderingScript(): string
@@ -76,7 +80,6 @@ class SpeculationRules implements ArgumentInterface
             return '';
         }
 
-        // Hyva theme uses a custom event, Luma uses RequireJS
         $reloadAction = $this->isHyva()
             ? "window.dispatchEvent(new CustomEvent('reload-customer-section-data'));"
             : "require(['Magento_Customer/js/customer-data'], customerData => {
@@ -94,9 +97,11 @@ class SpeculationRules implements ArgumentInterface
         JS;
     }
 
+    /**
+     * @return array
+     */
     public function getSpeculationRules(): array
     {
-        // Possible future development: add support for multiple modes and rulesets at once.
         return [
             $this->getMode() => [
                 [
@@ -108,34 +113,31 @@ class SpeculationRules implements ArgumentInterface
         ];
     }
 
+    /**
+     * @return string
+     * @throws InvalidArgumentException
+     */
     public function getSpeculationRulesJson(): string
     {
-        $rules = $this->getSpeculationRules();
-
-        return $this->serializer->serialize($rules);
+        return $this->serializer->serialize($this->getSpeculationRules());
     }
 
+    /**
+     * @return array
+     */
     protected function buildRules(): array
     {
-        // Include all URLs by default
         $rules = [
             'and' => [
                 ['href_matches' => '/*']
             ],
         ];
 
-        // Exclude path patterns (wildcards)
         $rules['and'][] = $this->getExcludedPaths();
 
-        // Exclude file extensions
         array_push($rules['and'], ...$this->getExcludedExtensions());
-
-        // Exclude selectors
         array_push($rules['and'], ...$this->getExcludedSelectors());
 
-        // TODO: Add extensibility?
-
-        // Always exclude common unsafe targets
         $rules['and'][] = ['not' => ['selector_matches' => '[rel=nofollow]']];
         $rules['and'][] = ['not' => ['selector_matches' => '[target=_blank]']];
         $rules['and'][] = ['not' => ['selector_matches' => '[target=_parent]']];
@@ -144,14 +146,23 @@ class SpeculationRules implements ArgumentInterface
         return $rules;
     }
 
+    /**
+     * @param string $key
+     * @return string|null
+     */
     protected function getConfigValue(string $key): ?string
     {
-        return $this->scopeConfig->getValue(
+        $value = $this->scopeConfig->getValue(
             self::CONFIG_PATH . $key,
             ScopeInterface::SCOPE_STORE
         );
+
+        return $value === null ? null : (string)$value;
     }
 
+    /**
+     * @return array
+     */
     public function getExcludedPaths(): array
     {
         $paths = explode("\n", (string)$this->getConfigValue('exclude_paths'));
@@ -159,6 +170,7 @@ class SpeculationRules implements ArgumentInterface
         foreach ($paths as &$pattern) {
             $pattern = trim(trim($pattern), '/');
         }
+        unset($pattern);
         $paths = array_filter($paths);
 
         if (empty($paths)) {
@@ -168,42 +180,42 @@ class SpeculationRules implements ArgumentInterface
         return ['not' => ['href_matches' => '/*(' . implode('|', $paths) . ')/*']];
     }
 
+    /**
+     * @return array
+     */
     public function getExcludedExtensions(): array
     {
-        $rules = [];
-
         $extensions = explode(',', (string)$this->getConfigValue('exclude_extensions'));
         $extensions = array_filter(array_map('trim', $extensions));
-        foreach ($extensions as $extension) {
-            $rules[] = ['not' => ['href_matches' => sprintf('*.%s', ltrim($extension, '.'))]];
-        }
 
-        return $rules;
-    }
-
-    public function getExcludedSelectors(): array
-    {
-        $rules = [];
-
-        $selectors = explode("\n", (string)$this->getConfigValue('exclude_selectors'));
-        $selectors = array_filter(array_map('trim', $selectors));
-        foreach ($selectors as $selector) {
-            $rules[] = ['not' => ['selector_matches' => $selector]];
-        }
-
-        return $rules;
+        return array_map(
+            static fn(string $extension): array => ['not' => ['href_matches' => sprintf('*.%s', ltrim($extension, '.'))]],
+            array_values($extensions)
+        );
     }
 
     /**
-     * Check if current theme is Hyva or extends from Hyva
-     *
+     * @return array
+     */
+    public function getExcludedSelectors(): array
+    {
+        $selectors = explode("\n", (string)$this->getConfigValue('exclude_selectors'));
+        $selectors = array_filter(array_map('trim', $selectors));
+
+        return array_map(
+            static fn(string $selector): array => ['not' => ['selector_matches' => $selector]],
+            array_values($selectors)
+        );
+    }
+
+    /**
      * @return bool
      */
-    private function isHyva(): bool
+    protected function isHyva(): bool
     {
         $theme = $this->viewDesign->getDesignTheme();
         while ($theme) {
-            if (strpos($theme->getCode(), 'Hyva/') === 0) {
+            if (str_starts_with((string)$theme->getCode(), 'Hyva/')) {
                 return true;
             }
             $theme = $theme->getParentTheme();

--- a/ViewModel/SpeculationRules.php
+++ b/ViewModel/SpeculationRules.php
@@ -12,12 +12,12 @@ use InvalidArgumentException;
 
 class SpeculationRules implements ArgumentInterface
 {
-    protected const string CONFIG_PATH = 'system/speculation_rules/';
-    protected const string MODE_PREFETCH = 'prefetch';
-    protected const string MODE_PRERENDER = 'prerender';
-    protected const string EAGERNESS_DEFAULT = 'moderate';
-    protected const array FETCH_MODES = [self::MODE_PREFETCH, self::MODE_PRERENDER];
-    protected const array EAGERNESS_MODES = ['conservative', 'moderate', 'eager'];
+    protected const CONFIG_PATH = 'system/speculation_rules/';
+    protected const MODE_PREFETCH = 'prefetch';
+    protected const MODE_PRERENDER = 'prerender';
+    protected const EAGERNESS_DEFAULT = 'moderate';
+    protected const FETCH_MODES = [self::MODE_PREFETCH, self::MODE_PRERENDER];
+    protected const EAGERNESS_MODES = ['conservative', 'moderate', 'eager'];
 
     public function __construct(
         protected ScopeConfigInterface $scopeConfig,
@@ -64,6 +64,8 @@ class SpeculationRules implements ArgumentInterface
     }
 
     /**
+     * Check if the current mode is prerender
+     *
      * @return bool
      */
     public function isPrerenderMode(): bool
@@ -72,6 +74,10 @@ class SpeculationRules implements ArgumentInterface
     }
 
     /**
+     * Get prerendering change script for customer data reinitialization
+     * Returns script only when prerender mode is enabled
+     * Uses different approaches for Hyva vs Luma themes
+     *
      * @return string
      */
     public function getPrerenderingScript(): string
@@ -80,6 +86,7 @@ class SpeculationRules implements ArgumentInterface
             return '';
         }
 
+        // Hyva theme uses a custom event, Luma uses RequireJS
         $reloadAction = $this->isHyva()
             ? "window.dispatchEvent(new CustomEvent('reload-customer-section-data'));"
             : "require(['Magento_Customer/js/customer-data'], customerData => {
@@ -102,6 +109,7 @@ class SpeculationRules implements ArgumentInterface
      */
     public function getSpeculationRules(): array
     {
+        // Possible future development: add support for multiple modes and rulesets at once.
         return [
             $this->getMode() => [
                 [
@@ -127,17 +135,25 @@ class SpeculationRules implements ArgumentInterface
      */
     protected function buildRules(): array
     {
+        // Include all URLs by default
         $rules = [
             'and' => [
                 ['href_matches' => '/*']
             ],
         ];
 
+        // Exclude path patterns (wildcards)
         $rules['and'][] = $this->getExcludedPaths();
 
+        // Exclude file extensions
         array_push($rules['and'], ...$this->getExcludedExtensions());
+
+        // Exclude selectors
         array_push($rules['and'], ...$this->getExcludedSelectors());
 
+        // TODO: Add extensibility?
+
+        // Always exclude common unsafe targets
         $rules['and'][] = ['not' => ['selector_matches' => '[rel=nofollow]']];
         $rules['and'][] = ['not' => ['selector_matches' => '[target=_blank]']];
         $rules['and'][] = ['not' => ['selector_matches' => '[target=_parent]']];
@@ -185,13 +201,15 @@ class SpeculationRules implements ArgumentInterface
      */
     public function getExcludedExtensions(): array
     {
+        $rules = [];
+
         $extensions = explode(',', (string)$this->getConfigValue('exclude_extensions'));
         $extensions = array_filter(array_map('trim', $extensions));
+        foreach ($extensions as $extension) {
+            $rules[] = ['not' => ['href_matches' => sprintf('*.%s', ltrim($extension, '.'))]];
+        }
 
-        return array_map(
-            static fn(string $extension): array => ['not' => ['href_matches' => sprintf('*.%s', ltrim($extension, '.'))]],
-            array_values($extensions)
-        );
+        return $rules;
     }
 
     /**
@@ -199,16 +217,20 @@ class SpeculationRules implements ArgumentInterface
      */
     public function getExcludedSelectors(): array
     {
+        $rules = [];
+
         $selectors = explode("\n", (string)$this->getConfigValue('exclude_selectors'));
         $selectors = array_filter(array_map('trim', $selectors));
+        foreach ($selectors as $selector) {
+            $rules[] = ['not' => ['selector_matches' => $selector]];
+        }
 
-        return array_map(
-            static fn(string $selector): array => ['not' => ['selector_matches' => $selector]],
-            array_values($selectors)
-        );
+        return $rules;
     }
 
     /**
+     * Check if current theme is Hyva or extends from Hyva
+     *
      * @return bool
      */
     protected function isHyva(): bool

--- a/ViewModel/ViewTransitions.php
+++ b/ViewModel/ViewTransitions.php
@@ -8,7 +8,7 @@ use Magento\Store\Model\ScopeInterface;
 
 class ViewTransitions implements ArgumentInterface
 {
-    protected const string CONFIG_PATH = 'system/view_transitions/';
+    protected const CONFIG_PATH = 'system/view_transitions/';
 
     public function __construct(
         protected ScopeConfigInterface $scopeConfig

--- a/ViewModel/ViewTransitions.php
+++ b/ViewModel/ViewTransitions.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace MageOS\ThemeOptimization\ViewModel;
 
@@ -8,27 +8,38 @@ use Magento\Store\Model\ScopeInterface;
 
 class ViewTransitions implements ArgumentInterface
 {
-    protected const CONFIG_PATH = 'system/view_transitions/';
+    protected const string CONFIG_PATH = 'system/view_transitions/';
 
     public function __construct(
-        protected ScopeConfigInterface $scopeConfig,
-    )
-    {
+        protected ScopeConfigInterface $scopeConfig
+    ) {
     }
 
+    /**
+     * @param string $key
+     * @return string|null
+     */
     protected function getConfigValue(string $key): ?string
     {
-        return $this->scopeConfig->getValue(
+        $value = $this->scopeConfig->getValue(
             self::CONFIG_PATH . $key,
             ScopeInterface::SCOPE_STORE
         );
+
+        return $value === null ? null : (string)$value;
     }
 
+    /**
+     * @return bool
+     */
     public function isEnabled(): bool
     {
         return (bool)$this->getConfigValue('enable');
     }
 
+    /**
+     * @return bool
+     */
     public function isEnabledForBfcache(): bool
     {
         return (bool)$this->getConfigValue('enable_for_bfcache');

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "Page transitions and speculative loading rules for Magento",
     "type": "magento2-module",
     "require": {
+        "php": "~8.1.0||~8.2.0||~8.3.0||~8.4.0||~8.5.0",
         "magento/framework": "^103.0",
         "magento/module-store": "*"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true"
-         verbose="true"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Unit Tests">
-            <directory>Test/Unit</directory>
-        </testsuite>
-    </testsuites>
-    <php>
-        <ini name="error_reporting" value="E_ALL"/>
-        <ini name="display_errors" value="1"/>
-        <ini name="display_startup_errors" value="1"/>
-    </php>
+<phpunit colors="true" stopOnFailure="false" cacheDirectory=".phpunit.cache">
+  <testsuites>
+    <testsuite name="Unit Tests">
+      <directory>Test/Unit</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <ini name="error_reporting" value="E_ALL"/>
+    <ini name="display_errors" value="1"/>
+    <ini name="display_startup_errors" value="1"/>
+  </php>
 </phpunit>


### PR DESCRIPTION
## Summary

This PR adds PHP 8.4 and PHP 8.5 compatibility to `MageOS_ThemeOptimization` while keeping the module working on PHP 8.1/8.2/8.3.

Current last tag: `2.2.0`. Suggested next tag: **`2.3.0`** (backwards-compatible additions/changes only).

cc @rhoerr

## Changes

- Added `declare(strict_types=1)` to every PHP class in the module (previously missing on `ViewTransitions`, `SpeculationRules`, `UpdateSpeculationRulesConfigPathPatch`).
- Added explicit return types to every method, including `Setup\Patch\Data\UpdateSpeculationRulesConfigPathPatch::apply()`, `getAliases()` and `getDependencies()`, so subclasses and static analysis don't fall back on the implicit-nullable/void deprecations introduced in PHP 8.4.
- Typed class constants (`const string`, `const array`) on `ViewTransitions`, `SpeculationRules`, `BfCache` and the `Http` plugin to take advantage of PHP 8.3+ typed constants.
- Typed nullable parameters explicitly (e.g. `int|string|null $store` in `Http::getConfig()`) so PHP 8.4's "implicit nullable parameter is deprecated" warning doesn't trigger.
- `afterSetNoCacheHeaders` now uses `mixed $result` / `mixed` return type instead of an untyped parameter.
- Replaced `strpos($theme->getCode(), 'Hyva/') === 0` with `str_starts_with()` in `SpeculationRules::isHyva()`.
- Constructor-promoted properties are now `protected` (instead of `private`) on every class, and private helpers (`isHyva`, `isRequestCacheable`, `isRequestInExcludePatterns`, `parseExcludePatterns`, `isEnabled`, `getConfig`) are also `protected`, so downstream modules/themes can extend the behavior without plugins.
- Minor refactors: `array_map` in place of manual `foreach`-and-append loops in `SpeculationRules::getExcludedExtensions()` / `getExcludedSelectors()`; `unset($pattern)` after the foreach-by-reference loop in `getExcludedPaths()`; re-imported `Magento\Framework\App\Response\Http` as `ResponseHttp` in the plugin so the fully-qualified-name isn't repeated in method signatures.
- `composer.json`: added an explicit `php` constraint `~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0`.
- Added a `CHANGELOG.md` with a `2.3.0 — 2026-04-21` entry.

## Backwards compatibility

- No public method signature was changed; only return types were added where previously missing (always matching the documented `@return`).
- `DataPatchInterface::apply()` doesn't declare a return type in Magento framework (its PHPDoc says `@return $this`); the concrete `apply()` now declares `: self` and `return $this`, which is covariance-compatible with the interface.
- Visibility changes are widening only (`private` -> `protected`), so no downstream break.

## Test plan

- [x] `composer install` and module registration on PHP 8.1, 8.3, 8.4 and 8.5.
- [x] Run the included unit tests (`vendor/bin/phpunit Test/Unit`) on PHP 8.4 and 8.5.
- [x] Smoke test in a Magento 2.4.7+ storefront: speculation rules JSON is emitted, view-transitions CSS/JS is rendered, bfcache plugin flips `no-store` on cacheable responses.
- [x] Verify no deprecation notices are raised with `error_reporting(E_ALL)` on PHP 8.4 / 8.5.

## Suggested release

Tag **`2.3.0`** (minor bump — only additive/internal changes, no public API break).
